### PR TITLE
soft_bfddpd: General enhancements and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,22 @@ BFD Data Plane
 
 This is a implementation of software based BFD data plane library to be used
 as base for hardware implementations.
+
+The project uses CMake so you can build the source out-of-the-tree like this:
+
+```sh
+# Enter source code directory:
+cd libbfddp
+
+# Create build dir separated from source:
+mkdir build
+cd build
+
+# Generate makefile (for production):
+cmake -DCMAKE_BUILD_TYPE=Release ..
+# Generate makefile (for debugging):
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+# Build library and sample daemons:
+make
+```

--- a/soft_bfddpd/bfddpd.c
+++ b/soft_bfddpd/bfddpd.c
@@ -360,7 +360,8 @@ bfddp_write_event(struct bfddp_ctx *bctx)
 		/* Connection closed. */
 		printf("%s: bfddp_write: closed connection\n",
 		       __func__);
-		exit(1);
+		is_terminating = true;
+		return;
 	}
 	if (rv > 0)
 		printf("=> Sent %zd bytes\n", rv);
@@ -381,7 +382,8 @@ bfddp_read_event(struct events_ctx *ec, struct bfddp_ctx *bctx)
 		/* Connection closed. */
 		printf("%s: bfddp_read: closed connection\n",
 		       __func__);
-		exit(1);
+		is_terminating = true;
+		return;
 	}
 	if (rv > 0)
 		printf("<= Received %zd bytes\n", rv);

--- a/soft_bfddpd/debug.c
+++ b/soft_bfddpd/debug.c
@@ -32,6 +32,31 @@
 #include "bfddp_packet.h"
 #include "bfddpd.h"
 
+static const char *bfd_session_states[] = {
+	"ADMIN DOWN",
+	"DOWN",
+	"INIT",
+	"UP"
+};
+
+_Static_assert(sizeof(bfd_session_states)/sizeof(*bfd_session_states) == (STATE_UP + 1),
+			   "bfd_session_states[] array item(s) missing!");
+
+static const char *bfd_session_diags[] = {
+	"Nothing",
+	"Control detection time expired",
+	"Echo function failed",
+	"Neighbor signaled down",
+	"Forwarding plane reset",
+	"Path down",
+	"Concatenated path down",
+	"Administratively down",
+	"Reverse concatenated path down"
+};
+
+_Static_assert(sizeof(bfd_session_diags)/sizeof(*bfd_session_diags) == (DIAG_REV_CONCAT_PATH_DOWN + 1),
+			   "bfd_session_diags[] array item(s) missing!");
+
 void
 bfd_session_debug(const struct bfd_session *bs, const char *fmt, ...)
 {
@@ -91,4 +116,22 @@ bfd_session_dump(const struct bfd_session *bs)
 		bs->bs_echo ? "echo " : "", bs->bs_tx, bs->bs_rx, bs->bs_erx,
 		bs->bs_rtx, bs->bs_rrx, bs->bs_rerx, bs->bs_dmultiplier,
 		bs->bs_rdmultiplier);
+}
+
+const char *bfd_session_get_state_string(enum bfd_state_value state)
+{
+	if ((state >= STATE_ADMINDOWN) && (state <= STATE_UP)) {
+		return bfd_session_states[state];
+	} else {
+		return "Unknown";
+	}
+}
+
+const char *bfd_session_get_diag_string(enum bfd_diagnostic_value diag)
+{
+	if ((diag >= DIAG_NOTHING) && (diag <= DIAG_REV_CONCAT_PATH_DOWN)) {
+		return bfd_session_diags[diag];
+	} else {
+		return "Unknown";
+	}
 }


### PR DESCRIPTION
This commit contains the following changes:
- Add instructions on how to build to the README file
- If bfddp_read() fails, close the socket before exiting (found by valgrind)
- Created static arrays to store the session state and diag strings based on
  a static assert to enforce the number of entires in the array at compile time
- Add functions for retrieving the session state and diag strings from the
  arrays
- Update BFD UDP port macros to match the values in RFC5881
- Added error statistics for when parsing BFD control packets
- Add function to change the state of a session
- Add function to generate a unique local discriminator