### PR TITLE
bfd_socket: Close socket on nonblock fail

### DIFF
--- a/soft_bfddpd/session.c
+++ b/soft_bfddpd/session.c
@@ -93,7 +93,7 @@ bfd_socket(struct sockaddr *sa)
 
 	if (sock_set_nonblock(sock) == -1) {
 		slog("fcntl: %s", strerror(errno));
-		return -1;
+		goto close_and_return;
 	}
 
 	switch (sa->sa_family) {


### PR DESCRIPTION
Goto close_and_return if sock_set_nonblock() fails.