### PR TITLE
libbfddp: BFD protocol handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(bfddp VERSION 0.1.0)
 add_library(
   libbfddp
   libbfddp/bfddp.c
+  libbfddp/bfddp_extra.c
   )
 
 add_executable(

--- a/bfddpd/bfddpd.c
+++ b/bfddpd/bfddpd.c
@@ -32,6 +32,7 @@
 #include <sys/un.h>
 #include <sys/time.h>
 
+#include <endian.h>
 #include <err.h>
 #include <errno.h>
 #include <poll.h>
@@ -200,36 +201,6 @@ parse_address(const char *arg, struct sockaddr *sa, socklen_t *salen)
 	}
 }
 
-static uint64_t
-hu64tonu64(uint64_t value)
-{
-	union {
-		uint32_t v32[2];
-		uint64_t v64;
-	} vu, *vp;
-
-	vp = (void *)&value;
-	vu.v32[0] = htonl(vp->v32[1]);
-	vu.v32[1] = htonl(vp->v32[0]);
-
-	return vu.v64;
-}
-
-static uint64_t
-nu64tohu64(uint64_t value)
-{
-	union {
-		uint32_t v32[2];
-		uint64_t v64;
-	} vu, *vp;
-
-	vp = (void *)&value;
-	vu.v32[0] = ntohl(vp->v32[1]);
-	vu.v32[1] = ntohl(vp->v32[0]);
-
-	return vu.v64;
-}
-
 static void
 bfddp_send_echo_request(struct bfddp_ctx *bctx)
 {
@@ -245,7 +216,7 @@ bfddp_send_echo_request(struct bfddp_ctx *bctx)
 	/* Payload data. */
 	gettimeofday(&tv, NULL);
 	msg.data.echo.dp_time =
-		hu64tonu64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
+		htobe64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
 
 	if (bfddp_write_enqueue(bctx, &msg) == 0)
 		errx(1, "%s: bfddp_write_enqueue failed", __func__);
@@ -266,7 +237,7 @@ bfddp_send_echo_reply(struct bfddp_ctx *bctx, uint64_t bfdd_time)
 	/* Payload data. */
 	gettimeofday(&tv, NULL);
 	msg.data.echo.dp_time =
-		hu64tonu64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
+		htobe64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
 	msg.data.echo.bfdd_time = bfdd_time;
 
 	if (bfddp_write_enqueue(bctx, &msg) == 0)
@@ -280,8 +251,8 @@ bfddp_process_echo_time(const struct bfddp_echo *echo)
 	struct timeval tv;
 
 	/* Collect registered timestamps. */
-	bfdt = nu64tohu64(echo->bfdd_time);
-	dpt = nu64tohu64(echo->dp_time);
+	bfdt = be64toh(echo->bfdd_time);
+	dpt = be64toh(echo->dp_time);
 
 	/* Measure new time. */
 	gettimeofday(&tv, NULL);

--- a/libbfddp/bfddp.c
+++ b/libbfddp/bfddp.c
@@ -360,7 +360,7 @@ bfddp_connect(struct bfddp_ctx *bctx, const struct sockaddr *sa,
 	}
 
 	/* Send packets as soon as we write to the socket. */
-	if (socktcp_set_nodelay(sock) == -1) {
+	if (sa->sa_family != AF_UNIX && socktcp_set_nodelay(sock) == -1) {
 		sock_close(sock);
 		return -1;
 	}

--- a/libbfddp/bfddp.c
+++ b/libbfddp/bfddp.c
@@ -343,6 +343,12 @@ bfddp_get_fd(const struct bfddp_ctx *bctx)
 	return bctx->sock;
 }
 
+void
+bfddp_set_fd(struct bfddp_ctx *bctx, int fd)
+{
+	bctx->sock = fd;
+}
+
 int
 bfddp_connect(struct bfddp_ctx *bctx, const struct sockaddr *sa,
 	      socklen_t salen)

--- a/libbfddp/bfddp.h
+++ b/libbfddp/bfddp.h
@@ -75,6 +75,15 @@ void bfddp_free(struct bfddp_ctx *bctx);
 int bfddp_get_fd(const struct bfddp_ctx *bctx);
 
 /**
+ * Sets the BFD Data Plane socket file descriptor. This function is useful when
+ * socket handling is made outside the library code for any reason.
+ *
+ * \param[in,out] bctx the BFD daemon communication context.
+ * \param[in] fd the socket file descriptor.
+ */
+void bfddp_set_fd(struct bfddp_ctx *bctx, int fd);
+
+/**
  * Creates the BFD daemon socket to exchange the messages.
  *
  * \param[in,out] bctx the BFD daemon communication context.

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -25,6 +25,7 @@
 
 #include <sys/time.h>
 
+#include <endian.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -723,7 +724,7 @@ bfddp_send_echo_request(struct bfddp_ctx *bctx)
 	/* Payload data. */
 	gettimeofday(&tv, NULL);
 	msg.data.echo.dp_time =
-		hu64tonu64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
+		htobe64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
 
 	return bfddp_write_enqueue(bctx, &msg);
 }
@@ -743,7 +744,7 @@ bfddp_send_echo_reply(struct bfddp_ctx *bctx, uint64_t bfdd_time)
 	/* Payload data. */
 	gettimeofday(&tv, NULL);
 	msg.data.echo.dp_time =
-		hu64tonu64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
+		htobe64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
 	msg.data.echo.bfdd_time = bfdd_time;
 
 	return bfddp_write_enqueue(bctx, &msg);
@@ -801,13 +802,13 @@ bfddp_session_reply_counters(struct bfddp_ctx *bctx, uint16_t id,
 
 	/* Fill payload. */
 	rmsg.data.session_counters.control_input_bytes =
-		hu64tonu64(bs->bs_crx_bytes);
+		htobe64(bs->bs_crx_bytes);
 	rmsg.data.session_counters.control_input_packets =
-		hu64tonu64(bs->bs_crx_packets);
+		htobe64(bs->bs_crx_packets);
 	rmsg.data.session_counters.control_output_bytes =
-		hu64tonu64(bs->bs_ctx_bytes);
+		htobe64(bs->bs_ctx_bytes);
 	rmsg.data.session_counters.control_output_packets =
-		hu64tonu64(bs->bs_ctx_packets);
+		htobe64(bs->bs_ctx_packets);
 
 	return bfddp_write_enqueue(bs->bs_bctx, &rmsg);
 }
@@ -815,36 +816,6 @@ bfddp_session_reply_counters(struct bfddp_ctx *bctx, uint16_t id,
 /*
  * Misc functions.
  */
-uint64_t
-hu64tonu64(uint64_t value)
-{
-	union {
-		uint32_t v32[2];
-		uint64_t v64;
-	} vu, *vp;
-
-	vp = (void *)&value;
-	vu.v32[0] = htonl(vp->v32[1]);
-	vu.v32[1] = htonl(vp->v32[0]);
-
-	return vu.v64;
-}
-
-uint64_t
-nu64tohu64(uint64_t value)
-{
-	union {
-		uint32_t v32[2];
-		uint64_t v64;
-	} vu, *vp;
-
-	vp = (void *)&value;
-	vu.v32[0] = ntohl(vp->v32[1]);
-	vu.v32[1] = ntohl(vp->v32[0]);
-
-	return vu.v64;
-}
-
 static uint32_t
 apply_jitter(uint32_t total, bool dm_one)
 {

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -60,6 +60,16 @@ bfddp_session_state_change_dummy(
 /* Our selected BFD integration callbacks. */
 struct bfddp_callbacks bfddp_callbacks;
 
+/** Macro to do callback check and print error when appropriated. */
+#define CALLBACK_CHECK(cb)                                                     \
+	do {                                                                   \
+		if (bfddp_callbacks.cb == NULL) {                              \
+			fprintf(stderr, "%s: callback " #cb " not set\n",      \
+				__func__);                                     \
+			exit(1);                                               \
+		}                                                              \
+	} while (0)
+
 void
 bfddp_initialize(struct bfddp_callbacks *bc)
 {
@@ -75,22 +85,11 @@ bfddp_initialize(struct bfddp_callbacks *bc)
 		bfddp_callbacks.bc_state_change =
 			bfddp_session_state_change_dummy;
 
-#define CALLBACK_CHECK(cb)                                                     \
-	do {                                                                   \
-		if (bfddp_callbacks.cb == NULL) {                              \
-			fprintf(stderr, "%s: callback " #cb " not set\n",      \
-				__func__);                                     \
-			exit(1);                                               \
-		}                                                              \
-	} while (0)
-
 	CALLBACK_CHECK(bc_tx_control);
 	CALLBACK_CHECK(bc_tx_control_update);
 	CALLBACK_CHECK(bc_tx_control_stop);
 	CALLBACK_CHECK(bc_rx_control_update);
 	CALLBACK_CHECK(bc_rx_control_stop);
-
-#undef CALLBACK_CHECK
 }
 
 /*

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -850,10 +850,9 @@ apply_jitter(uint32_t total, bool dm_one)
 {
 	uint32_t jitter;
 
-	if (dm_one)
-		jitter = (uint32_t)(random() % 11);
-	else
-		jitter = (uint32_t)(random() % 26);
+	jitter = (uint32_t)(random()
+			    % (dm_one ? (BFD_DM_ONE_MAX_JITTER + 1)
+				      : (BFD_DM_MAX_JITTER + 1)));
 
 	return total - (total * (jitter / 100));
 }

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -1,0 +1,844 @@
+/*
+ * BFD Data Plane library implementation.
+ *
+ * Copyright (C) 2020 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael F. Zalamena
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <sys/time.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bfddp_extra.h"
+
+/*
+ * Callback handling.
+ */
+
+static int
+bfddp_session_new_dummy(__attribute__((unused)) struct bfd_session *bs,
+			__attribute__((unused)) void *arg)
+{
+	return 0;
+}
+
+static void
+bfddp_session_update_dummy(__attribute__((unused)) struct bfd_session *bs,
+			   __attribute__((unused)) void *arg)
+{
+}
+
+static void
+bfddp_session_state_change_dummy(
+	__attribute__((unused)) struct bfd_session *bs,
+	__attribute__((unused)) void *arg,
+	__attribute__((unused)) enum bfd_state_value ostate,
+	__attribute__((unused)) enum bfd_state_value nstate)
+{
+}
+
+/* Our selected BFD integration callbacks. */
+struct bfddp_callbacks bfddp_callbacks;
+
+void
+bfddp_initialize(struct bfddp_callbacks *bc)
+{
+	bfddp_callbacks = *bc;
+
+	if (bfddp_callbacks.bc_session_new == NULL)
+		bfddp_callbacks.bc_session_new = bfddp_session_new_dummy;
+	if (bfddp_callbacks.bc_session_update == NULL)
+		bfddp_callbacks.bc_session_update = bfddp_session_update_dummy;
+	if (bfddp_callbacks.bc_session_free == NULL)
+		bfddp_callbacks.bc_session_free = bfddp_session_update_dummy;
+	if (bfddp_callbacks.bc_state_change == NULL)
+		bfddp_callbacks.bc_state_change =
+			bfddp_session_state_change_dummy;
+
+#define CALLBACK_CHECK(cb)                                                     \
+	do {                                                                   \
+		if (bfddp_callbacks.cb == NULL) {                              \
+			fprintf(stderr, "%s: callback " #cb " not set\n",      \
+				__func__);                                     \
+			exit(1);                                               \
+		}                                                              \
+	} while (0)
+
+	CALLBACK_CHECK(bc_tx_control);
+	CALLBACK_CHECK(bc_tx_control_update);
+	CALLBACK_CHECK(bc_tx_control_stop);
+	CALLBACK_CHECK(bc_rx_control_update);
+	CALLBACK_CHECK(bc_rx_control_stop);
+
+#undef CALLBACK_CHECK
+}
+
+/*
+ * Session functions.
+ */
+static void
+bfddp_session_set_slowstart(struct bfd_session *bs)
+{
+	/* Slow start settings. */
+	bs->bs_cur_dmultiplier = SLOWSTART_DMULT;
+	bs->bs_cur_tx = SLOWSTART_TX;
+	bs->bs_cur_rx = SLOWSTART_RX;
+	bs->bs_cur_erx = SLOWSTART_ERX;
+}
+
+static void
+bfddp_session_reset_remote(struct bfd_session *bs)
+{
+	/* Default remote settings. */
+	bs->bs_rdmultiplier = SLOWSTART_DMULT;
+	bs->bs_rtx = SLOWSTART_TX;
+	bs->bs_rrx = SLOWSTART_RX;
+	bs->bs_rerx = SLOWSTART_ERX;
+}
+
+void
+bfddp_session_update(struct bfd_session *bs, void *arg,
+		     const struct bfddp_session *bds)
+{
+	bool timers_changed = false;
+	struct in_addr *ia;
+	uint16_t port;
+	uint32_t min_rx, min_tx;
+	uint32_t flags = ntohl(bds->flags);
+
+	/*
+	 * Load flags.
+	 *
+	 * NOTE: normalize boolean values (e.g. `!!`) so packet build functions
+	 * can use it with shift (e.g. (multihop << X)).
+	 */
+	bs->bs_admin_shutdown = !!(flags & SESSION_SHUTDOWN);
+	bs->bs_multihop = !!(flags & SESSION_MULTIHOP);
+	bs->bs_passive = !!(flags & SESSION_PASSIVE);
+	bs->bs_demand = !!(flags & SESSION_DEMAND);
+	bs->bs_cbit = !!(flags & SESSION_CBIT);
+	bs->bs_echo = !!(flags & SESSION_ECHO);
+
+	if (bs->bs_multihop)
+		port = htons(BFD_MULTI_HOP_PORT);
+	else
+		port = htons(BFD_SINGLE_HOP_PORT);
+
+	bs->bs_ipv4 = !(bds->flags & SESSION_IPV6);
+	if (bs->bs_ipv4) {
+		ia = (struct in_addr *)&bds->src;
+		bs->bs_src.bs_src_sin.sin_family = AF_INET;
+		bs->bs_src.bs_src_sin.sin_addr.s_addr = ia->s_addr;
+
+		ia = (struct in_addr *)&bds->dst;
+		bs->bs_dst.bs_dst_sin.sin_family = AF_INET;
+		bs->bs_dst.bs_dst_sin.sin_addr.s_addr = ia->s_addr;
+		bs->bs_dst.bs_dst_sin.sin_port = port;
+	} else {
+		bs->bs_src.bs_src_sin6.sin6_family = AF_INET6;
+		memcpy(&bs->bs_src.bs_src_sin6.sin6_addr, &bds->src,
+		       sizeof(struct in6_addr));
+		if (IN6_IS_ADDR_LINKLOCAL(&bs->bs_src.bs_src_sin6.sin6_addr))
+			bs->bs_src.bs_src_sin6.sin6_scope_id = bds->ifindex;
+
+		bs->bs_dst.bs_dst_sin6.sin6_family = AF_INET6;
+		memcpy(&bs->bs_dst.bs_dst_sin6.sin6_addr, &bds->dst,
+		       sizeof(struct in6_addr));
+		bs->bs_dst.bs_dst_sin6.sin6_port = port;
+		if (IN6_IS_ADDR_LINKLOCAL(&bs->bs_dst.bs_dst_sin6.sin6_addr))
+			bs->bs_dst.bs_dst_sin6.sin6_scope_id = bds->ifindex;
+	}
+
+	/* Load timers. */
+	min_tx = ntohl(bds->min_tx);
+	min_rx = ntohl(bds->min_rx);
+	if (bs->bs_tx != min_tx || bs->bs_rx != min_rx)
+		timers_changed = true;
+
+	bs->bs_tx = min_tx;
+	bs->bs_rx = min_rx;
+	bs->bs_erx = ntohl(bds->min_echo_rx);
+	bs->bs_hold = ntohl(bds->hold_time);
+	bs->bs_dmultiplier = bds->detect_mult;
+
+	bs->bs_minttl = bds->ttl;
+	bs->bs_ifindex = ntohl(bds->ifindex);
+	if (bds->ifname[0])
+		snprintf(bs->bs_ifname, sizeof(bs->bs_ifname), "%s",
+			 bds->ifname);
+
+	bfddp_callbacks.bc_session_update(bs, arg);
+
+	/* Handle administrative shutdown. */
+	if (bs->bs_admin_shutdown) {
+		/* Send a control packet to tell we are shutting down. */
+		bs->bs_state = STATE_ADMINDOWN;
+		bfddp_send_control_packet(bs, arg);
+
+		/* Stop all timers. */
+		bfddp_callbacks.bc_rx_control_stop(bs, arg);
+		bfddp_callbacks.bc_tx_control_stop(bs, arg);
+		return;
+	}
+
+	/*
+	 * If we were shutdown, then transition between administrative down to
+	 * down.
+	 */
+	if (bs->bs_state == STATE_ADMINDOWN) {
+		bs->bs_state = STATE_DOWN;
+		/* Notify application about ADMINDOWN transition. */
+		bfddp_callbacks.bc_state_change(bs, arg, STATE_ADMINDOWN,
+						STATE_DOWN);
+	}
+
+	/*
+	 * Control plane asked for passive mode: stop sending packets
+	 * if the remote peer is down or unknown, otherwise enable it.
+	 */
+	if (bs->bs_passive && bs->bs_state == STATE_DOWN) {
+		bfddp_callbacks.bc_rx_control_stop(bs, arg);
+		bfddp_callbacks.bc_tx_control_stop(bs, arg);
+		return;
+	}
+
+	/*
+	 * Timers changes happens when the session is new or the previous
+	 * configured interval is different.
+	 */
+	if (timers_changed && bs->bs_state == STATE_UP)
+		bs->bs_poll = true;
+
+	bfddp_callbacks.bc_rx_control_update(bs, arg);
+	bfddp_callbacks.bc_tx_control_update(bs, arg);
+}
+
+struct bfd_session *
+bfddp_session_new(struct bfddp_ctx *bctx, void *arg,
+		  const struct bfddp_session *bds)
+{
+	struct bfd_session *bs;
+
+	bs = calloc(1, sizeof(*bs));
+	if (bs == NULL)
+		return NULL;
+
+	/* Point to our data plane context. */
+	bs->bs_bctx = bctx;
+
+	/* Local settings. */
+	bs->bs_lid = ntohl(bds->lid);
+	bs->bs_state = STATE_DOWN;
+	bfddp_session_set_slowstart(bs);
+
+	/* Remote settings. */
+	bs->bs_rstate = STATE_DOWN;
+	bfddp_session_reset_remote(bs);
+
+	/* Tell application that it can use our data. */
+	if (bfddp_callbacks.bc_session_new(bs, arg) == -1) {
+		free(bs);
+		return NULL;
+	}
+
+	/* Re use the update code. */
+	bfddp_session_update(bs, arg, bds);
+
+	return bs;
+}
+
+void
+bfddp_session_free(struct bfd_session **bs, void *arg)
+{
+	/* Check if pointer is already NULL. */
+	if ((*bs) == NULL)
+		return;
+
+	/* Call application `free()` first, then free our data. */
+	bfddp_callbacks.bc_session_free(*bs, arg);
+
+	/* Free our resources. */
+	free(*bs);
+	*bs = NULL;
+}
+
+ssize_t
+bfddp_send_control_packet(struct bfd_session *bs, void *arg)
+{
+	struct bfddp_control_packet bcp = {};
+	bool poll = bs->bs_poll;
+	uint8_t state = bs->bs_state & 0x03;
+	ssize_t rv;
+
+	/* Sanity check: don't allow POLL and FINAL in the same packet. */
+	if (bs->bs_poll && bs->bs_final)
+		poll = false;
+
+	bcp.version_diag = (uint8_t)((1 << 5) | (bs->bs_diag & 0x1F));
+	bcp.state_bits =
+		(uint8_t)((state << 6u)		  /* Current state. */
+			  | (poll << 5u)	  /* Poll bit */
+			  | (bs->bs_final << 4u)  /* Final bit */
+			  | (bs->bs_cbit << 3u)	  /* Control Plane I. bit */
+			  | (0 << 2u)		  /* Authentication bit. */
+			  | (bs->bs_demand << 1u) /* Demand mode bit */
+			  | (0 << 0u));		  /* Multi point bit. */
+
+	bcp.detection_multiplier = bs->bs_dmultiplier;
+	bcp.length = sizeof(bcp);
+	bcp.local_id = htonl(bs->bs_lid);
+	bcp.remote_id = htonl(bs->bs_rid);
+
+	switch (bs->bs_state) {
+	case STATE_ADMINDOWN:
+	case STATE_DOWN:
+		bcp.desired_tx = htonl(bs->bs_cur_tx);
+		bcp.required_rx = htonl(bs->bs_cur_rx);
+		bcp.required_echo_rx = htonl(bs->bs_cur_erx);
+		break;
+	case STATE_INIT:
+	case STATE_UP:
+		bcp.desired_tx = htonl(bs->bs_tx);
+		bcp.required_rx = htonl(bs->bs_rx);
+		bcp.required_echo_rx = htonl(bs->bs_erx);
+		break;
+	}
+
+	rv = bfddp_callbacks.bc_tx_control(bs, arg, &bcp);
+
+	/* Update session output data. */
+	if (rv > 0) {
+		bs->bs_ctx_bytes += (size_t)rv;
+		bs->bs_ctx_packets++;
+	}
+
+	return rv;
+}
+
+void
+bfddp_session_rx_timeout(struct bfd_session *bs, void *arg)
+{
+	enum bfd_state_value pstate = bs->bs_state;
+
+	bfddp_session_reset_remote(bs);
+
+	/* Tell FRR's BFD daemon the session is down. */
+	bs->bs_state = STATE_DOWN;
+	bs->bs_diag = bs->bs_rdiag = DIAG_CONTROL_EXPIRED;
+	bfddp_session_set_slowstart(bs);
+
+	/* Disable timers if configured for passive mode. */
+	if (bs->bs_passive) {
+		bfddp_callbacks.bc_rx_control_stop(bs, arg);
+		bfddp_callbacks.bc_tx_control_stop(bs, arg);
+	}
+
+	/*
+	 * Only send notification if state changed.
+	 *
+	 * This prevents a extra notification in case the remote peer
+	 * asked and ceased to send control packets earlier than expiration
+	 * timer.
+	 */
+	if (bs->bs_state != pstate)
+		bfddp_send_session_state_change(bs);
+
+	/* Notify application about state change. */
+	bfddp_callbacks.bc_state_change(bs, arg, pstate, bs->bs_state);
+}
+
+static void
+bfddp_session_sm_admindown(__attribute__((unused)) struct bfd_session *bs,
+			   __attribute__((unused)) void *arg,
+			   __attribute__((unused)) enum bfd_state_value nstate)
+{
+	/* NOTHING. */
+}
+
+static void
+bfddp_session_sm_down(struct bfd_session *bs, void *arg,
+		      enum bfd_state_value nstate)
+{
+	switch (nstate) {
+	case STATE_ADMINDOWN:
+		/* NOTHING. */
+		break;
+	case STATE_DOWN:
+		bs->bs_state = STATE_INIT;
+
+		/* Notify state change. */
+		bfddp_send_session_state_change(bs);
+
+		/*
+		 * If passive mode we must manually send packet (TX timer is
+		 * disabled).
+		 */
+		if (bs->bs_passive)
+			bfddp_send_control_packet(bs, arg);
+		break;
+	case STATE_INIT:
+		bs->bs_state = STATE_UP;
+
+		/* Start polling. */
+		bs->bs_poll = true;
+
+		/* Notify state change. */
+		bfddp_send_session_state_change(bs);
+		break;
+	case STATE_UP:
+		/* NOTHING: we haven't and the peer hasn't sent INIT yet. */
+		break;
+	}
+}
+
+static void
+bfddp_session_sm_init(struct bfd_session *bs, void *arg,
+		      enum bfd_state_value nstate)
+{
+	switch (nstate) {
+	case STATE_ADMINDOWN:
+		bs->bs_state = STATE_DOWN;
+
+		/* Notify state change. */
+		bfddp_send_session_state_change(bs);
+		break;
+	case STATE_DOWN:
+		/*
+		 * We are waiting peer's INIT.
+		 *
+		 * If we are passive, then we must manually respond to this
+		 * packet (TX timer is disabled).
+		 */
+		if (bs->bs_passive)
+			bfddp_send_control_packet(bs, arg);
+		break;
+	case STATE_INIT:
+		/* FALLTHROUGH. */
+	case STATE_UP:
+		bs->bs_state = STATE_UP;
+		bs->bs_diag = 0;
+
+		/* Start polling. */
+		bs->bs_poll = true;
+
+		/* Notify state change. */
+		bfddp_send_session_state_change(bs);
+		break;
+	}
+}
+
+static void
+bfddp_session_sm_up(struct bfd_session *bs, __attribute__((unused)) void *arg,
+		    enum bfd_state_value nstate)
+{
+	switch (nstate) {
+	case STATE_ADMINDOWN:
+		/* FALLTHROUGH. */
+	case STATE_DOWN:
+		bs->bs_state = STATE_DOWN;
+
+		bfddp_session_set_slowstart(bs);
+		/* Disable echo timers. */
+
+		/* Notify state change. */
+		bfddp_send_session_state_change(bs);
+		break;
+	case STATE_INIT:
+		/* FALLTHROUGH. */
+	case STATE_UP:
+		/* NOTHING. */
+		break;
+	}
+}
+
+void
+bfddp_session_state_machine(struct bfd_session *bs, void *arg,
+			    enum bfd_state_value nstate)
+{
+	enum bfd_state_value ostate = bs->bs_state;
+
+	switch (ostate) {
+	case STATE_ADMINDOWN:
+		bfddp_session_sm_admindown(bs, arg, nstate);
+		break;
+	case STATE_DOWN:
+		bfddp_session_sm_down(bs, arg, nstate);
+		break;
+	case STATE_INIT:
+		bfddp_session_sm_init(bs, arg, nstate);
+		break;
+	case STATE_UP:
+		bfddp_session_sm_up(bs, arg, nstate);
+		break;
+	}
+
+	/* Call application callback to notify about state change. */
+	if (ostate != bs->bs_state) {
+		/*
+		 * If state changed from UP to DOWN and we are in passive mode,
+		 * then * we need to disable the RX/TX timers to avoid sending
+		 * new control packets.
+		 */
+		if (bs->bs_passive
+		    && (ostate == STATE_UP && bs->bs_state == STATE_DOWN)) {
+			bfddp_callbacks.bc_rx_control_stop(bs, arg);
+			bfddp_callbacks.bc_tx_control_stop(bs, arg);
+		}
+
+		bfddp_callbacks.bc_state_change(bs, arg, ostate, bs->bs_state);
+	}
+}
+
+enum bfddp_packet_validation
+bfddp_session_validate_packet(const struct bfddp_control_packet *bcp,
+			      size_t bcplen)
+{
+	enum bfd_state_value state;
+	uint8_t version;
+
+	/* Assert we have the received the whole packet. */
+	if (bcplen < (int)sizeof(*bcp))
+		return BPV_PACKET_TOO_SMALL;
+
+	/* Check packet header length. */
+	if (bcp->length < sizeof(*bcp) || bcp->length > bcplen)
+		return BPV_INVALID_LENGTH;
+
+	/* Check version. */
+	version = (bcp->version_diag >> 5) & 0x07;
+	if (version != BFD_PROTOCOL_VERSION)
+		return BPV_INVALID_VERSION;
+
+	/* Invalid detection multiplier. */
+	if (bcp->detection_multiplier == 0)
+		return BPV_ZERO_MULTIPLIER;
+
+	/* Discard sessions using ID zero. */
+	if (bcp->local_id == 0)
+		return BPV_ZERO_LOCAL_ID;
+
+	/* Invalid remote ID with established session. */
+	state = (bcp->state_bits >> 6);
+	if ((state == STATE_INIT || state == STATE_UP) && bcp->remote_id == 0)
+		return BPV_INVALID_REMOTE_ID;
+
+	return BPV_OK;
+}
+
+void
+bfddp_session_rx_packet(struct bfd_session *bs, void *arg,
+			const struct bfddp_control_packet *bcp)
+{
+	enum bfd_state_value state = (bcp->state_bits >> 6);
+	bool timers_changed = false;
+
+	/* Update session input data. */
+	bs->bs_crx_bytes += sizeof(*bcp);
+	bs->bs_crx_packets++;
+
+	/* Copy remote system status. */
+	bs->bs_rstate = state;
+	bs->bs_rdiag = bcp->version_diag & 0x1F;
+	bs->bs_rid = ntohl(bcp->local_id);
+
+	/* Detect timers change: */
+	if (ntohl(bcp->desired_tx) != bs->bs_rtx)
+		timers_changed = true;
+	else if (ntohl(bcp->required_rx) != bs->bs_rrx)
+		timers_changed = true;
+	else if (ntohl(bcp->required_echo_rx) != bs->bs_rerx)
+		timers_changed = true;
+	else if (bcp->detection_multiplier != bs->bs_rdmultiplier)
+		timers_changed = true;
+
+	bs->bs_rtx = ntohl(bcp->desired_tx);
+	bs->bs_rrx = ntohl(bcp->required_rx);
+	bs->bs_rerx = ntohl(bcp->required_echo_rx);
+	bs->bs_rdmultiplier = bcp->detection_multiplier;
+	bs->bs_rcbit = !!(bcp->state_bits & STATE_CPI_BIT);
+	bs->bs_rdemand = !!(bcp->state_bits & STATE_DEMAND_BIT);
+
+	/* Skip the rest if this session is shutdown. */
+	if (bs->bs_admin_shutdown)
+		return;
+
+	/*
+	 * RFC 5880 Section 6.8.6. Reception of BFD Control Packets:
+	 *
+	 * > If a Poll Sequence is being transmitted by the local system
+	 * > and the Final (F) bit in the received packet is set, the
+	 * > Poll Sequence MUST be terminated.
+	 */
+	if (bs->bs_poll && (bcp->state_bits & STATE_FINAL_BIT)) {
+		bs->bs_poll = false;
+		bs->bs_final = false;
+
+		/* Negotiation ended, apply new intervals. */
+		bs->bs_cur_dmultiplier = bs->bs_dmultiplier;
+		bs->bs_cur_tx = bs->bs_tx;
+		bs->bs_cur_rx = bs->bs_rx;
+		bs->bs_cur_erx = bs->bs_erx;
+
+		/* Tell control plane about timers change. */
+		bfddp_send_session_state_change(bs);
+	} else {
+		if (timers_changed) {
+			/*
+			 * Notify control plane about new timers if this is not
+			 * the final event.
+			 */
+			bfddp_send_session_state_change(bs);
+
+			/*
+			 * Update transmission timer to avoid session
+			 * disruption.
+			 *
+			 * NOTE:
+			 * Receive timer update will be called later this
+			 * function.
+			 */
+			bfddp_callbacks.bc_tx_control_update(bs, arg);
+		}
+	}
+
+	/*
+	 * RFC 5880 Section 6.8.6. Reception of BFD Control Packets:
+	 *
+	 * > If the Poll (P) bit is set, send a BFD Control packet to the
+	 * > remote system with the Poll (P) bit clear, and the Final (F)
+	 * > bit set (see section 6.8.7).
+	 */
+	if (bcp->state_bits & STATE_POLL_BIT) {
+		bs->bs_poll = false;
+		bs->bs_final = true;
+
+		/* Speed up session convergence. */
+		bfddp_send_control_packet(bs, arg);
+
+		bs->bs_final = false;
+	}
+
+	bfddp_session_state_machine(bs, arg, bs->bs_rstate);
+
+	/* We received the peer packet, update the expiration timer. */
+	bfddp_callbacks.bc_rx_control_update(bs, arg);
+
+	/* Handle echo timer not implemented. */
+}
+
+/*
+ * FRR BFD communication functions.
+ */
+size_t
+bfddp_send_echo_request(struct bfddp_ctx *bctx)
+{
+	struct bfddp_message msg = {};
+	struct timeval tv;
+
+	/* Prepare header. */
+	msg.header.version = BFD_DP_VERSION;
+	msg.header.length = htons(sizeof(struct bfddp_message_header)
+				  + sizeof(struct bfddp_echo));
+	msg.header.type = htons(ECHO_REQUEST);
+
+	/* Payload data. */
+	gettimeofday(&tv, NULL);
+	msg.data.echo.dp_time =
+		hu64tonu64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
+
+	return bfddp_write_enqueue(bctx, &msg);
+}
+
+size_t
+bfddp_send_echo_reply(struct bfddp_ctx *bctx, uint64_t bfdd_time)
+{
+	struct bfddp_message msg = {};
+	struct timeval tv;
+
+	/* Prepare header. */
+	msg.header.version = BFD_DP_VERSION;
+	msg.header.length = htons(sizeof(struct bfddp_message_header)
+				  + sizeof(struct bfddp_echo));
+	msg.header.type = htons(ECHO_REPLY);
+
+	/* Payload data. */
+	gettimeofday(&tv, NULL);
+	msg.data.echo.dp_time =
+		hu64tonu64((uint64_t)((tv.tv_sec * 1000000) + tv.tv_usec));
+	msg.data.echo.bfdd_time = bfdd_time;
+
+	return bfddp_write_enqueue(bctx, &msg);
+}
+
+size_t
+bfddp_send_session_state_change(const struct bfd_session *bs)
+{
+	struct bfddp_message msg = {};
+
+	/* Prepare header. */
+	msg.header.version = BFD_DP_VERSION;
+	msg.header.length = htons(sizeof(msg.header) + sizeof(msg.data.state));
+	msg.header.type = htons(BFD_STATE_CHANGE);
+
+	/* Prepare payload. */
+	msg.data.state.lid = htonl(bs->bs_lid);
+	msg.data.state.rid = htonl(bs->bs_rid);
+	msg.data.state.state = (uint8_t)bs->bs_state;
+	msg.data.state.diagnostics = (uint8_t)bs->bs_rdiag;
+	msg.data.state.detection_multiplier = bs->bs_rdmultiplier;
+	msg.data.state.desired_tx = htonl(bs->bs_rtx);
+	msg.data.state.required_rx = htonl(bs->bs_rrx);
+	msg.data.state.required_echo_rx = htonl(bs->bs_rerx);
+
+	if (bs->bs_rcbit)
+		msg.data.state.remote_flags |= RBIT_CPI;
+	if (bs->bs_rdemand)
+		msg.data.state.remote_flags |= RBIT_DEMAND;
+
+	msg.data.state.remote_flags = htonl(msg.data.state.remote_flags);
+
+	return bfddp_write_enqueue(bs->bs_bctx, &msg);
+}
+
+size_t
+bfddp_session_reply_counters(struct bfddp_ctx *bctx, uint16_t id,
+			     const struct bfd_session *bs)
+{
+	struct bfddp_message rmsg = {};
+	uint16_t msglen =
+		sizeof(rmsg.header) + sizeof(rmsg.data.session_counters);
+
+	/* Fill in message header. */
+	rmsg.header.version = BFD_DP_VERSION;
+	rmsg.header.length = htons(msglen);
+	rmsg.header.type = htons(BFD_SESSION_COUNTERS);
+	rmsg.header.id = id;
+
+	/* Failed to find session. */
+	if (bs == NULL) {
+		/* Send answer anyway so it doesn't wait forever. */
+		return bfddp_write_enqueue(bctx, &rmsg);
+	}
+
+	/* Fill payload. */
+	rmsg.data.session_counters.control_input_bytes =
+		hu64tonu64(bs->bs_crx_bytes);
+	rmsg.data.session_counters.control_input_packets =
+		hu64tonu64(bs->bs_crx_packets);
+	rmsg.data.session_counters.control_output_bytes =
+		hu64tonu64(bs->bs_ctx_bytes);
+	rmsg.data.session_counters.control_output_packets =
+		hu64tonu64(bs->bs_ctx_packets);
+
+	return bfddp_write_enqueue(bs->bs_bctx, &rmsg);
+}
+
+/*
+ * Misc functions.
+ */
+uint64_t
+hu64tonu64(uint64_t value)
+{
+	union {
+		uint32_t v32[2];
+		uint64_t v64;
+	} vu, *vp;
+
+	vp = (void *)&value;
+	vu.v32[0] = htonl(vp->v32[1]);
+	vu.v32[1] = htonl(vp->v32[0]);
+
+	return vu.v64;
+}
+
+uint64_t
+nu64tohu64(uint64_t value)
+{
+	union {
+		uint32_t v32[2];
+		uint64_t v64;
+	} vu, *vp;
+
+	vp = (void *)&value;
+	vu.v32[0] = ntohl(vp->v32[1]);
+	vu.v32[1] = ntohl(vp->v32[0]);
+
+	return vu.v64;
+}
+
+static uint32_t
+apply_jitter(uint32_t total, bool dm_one)
+{
+	uint32_t jitter;
+
+	if (dm_one)
+		jitter = (uint32_t)(random() % 11);
+	else
+		jitter = (uint32_t)(random() % 26);
+
+	return total - (total * (jitter / 100));
+}
+
+uint32_t
+bfddp_session_next_control_tx_interval(struct bfd_session *bs)
+{
+	uint32_t selected_timer;
+
+	/*
+	 * RFC 5880 Section 6.8.7. Transmitting BFD Control Packets:
+	 * Select the larger of 'Desired Transmission' and 'Remote Min Recv.'.
+	 */
+	if (bs->bs_cur_tx > bs->bs_rrx)
+		selected_timer = bs->bs_cur_tx;
+	else
+		selected_timer = bs->bs_rrx;
+
+	return apply_jitter(selected_timer, bs->bs_rdmultiplier == 1);
+}
+
+uint32_t
+bfddp_session_next_control_rx_interval(struct bfd_session *bs)
+{
+	uint32_t next_to;
+
+	/*
+	 * RFC 5880 Section 6.8.4. Calculating the Detection Time:
+	 *
+	 * > In Asynchronous mode, the Detection Time calculated in the local
+	 * > system is equal to the value of Detect Mult received from the
+	 * > remote system, multiplied by the agreed transmit interval of the
+	 * > remote system (the greater of bfd.RequiredMinRxInterval and the
+	 * > last received Desired Min TX Interval). The Detect Mult value is
+	 * > (roughly speaking, due to jitter) the number of packets that have
+	 * > to be missed in a row to declare the session to be down.
+	 *
+	 * Extra bit: wait for polling to end before start using the requested
+	 * intervals.
+	 */
+	if ((bs->bs_cur_rx > bs->bs_rtx) || bs->bs_poll)
+		next_to = bs->bs_cur_rx * bs->bs_rdmultiplier;
+	else
+		next_to = bs->bs_rtx * bs->bs_rdmultiplier;
+
+	return next_to;
+}

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -800,7 +800,7 @@ apply_jitter(uint32_t total, bool dm_one)
 }
 
 uint32_t
-bfddp_session_next_control_tx_interval(struct bfd_session *bs)
+bfddp_session_next_control_tx_interval(struct bfd_session *bs, bool add_jitter)
 {
 	uint32_t selected_timer;
 
@@ -813,7 +813,10 @@ bfddp_session_next_control_tx_interval(struct bfd_session *bs)
 	else
 		selected_timer = bs->bs_rrx;
 
-	return apply_jitter(selected_timer, bs->bs_rdmultiplier == 1);
+	if (add_jitter)
+		return apply_jitter(selected_timer, bs->bs_rdmultiplier == 1);
+
+	return selected_timer;
 }
 
 uint32_t

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -625,14 +625,10 @@ bfddp_session_rx_packet(struct bfd_session *bs, void *arg,
 	bs->bs_rid = ntohl(bcp->local_id);
 
 	/* Detect timers change: */
-	if (ntohl(bcp->desired_tx) != bs->bs_rtx)
-		timers_changed = true;
-	else if (ntohl(bcp->required_rx) != bs->bs_rrx)
-		timers_changed = true;
-	else if (ntohl(bcp->required_echo_rx) != bs->bs_rerx)
-		timers_changed = true;
-	else if (bcp->detection_multiplier != bs->bs_rdmultiplier)
-		timers_changed = true;
+	timers_changed |= (ntohl(bcp->desired_tx) != bs->bs_rtx);
+	timers_changed |= (ntohl(bcp->required_rx) != bs->bs_rrx);
+	timers_changed |= (ntohl(bcp->required_echo_rx) != bs->bs_rerx);
+	timers_changed |= (bcp->detection_multiplier != bs->bs_rdmultiplier);
 
 	bs->bs_rtx = ntohl(bcp->desired_tx);
 	bs->bs_rrx = ntohl(bcp->required_rx);

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -534,21 +534,24 @@ bfddp_session_state_machine(struct bfd_session *bs, void *arg,
 		break;
 	}
 
-	/* Call application callback to notify about state change. */
-	if (ostate != bs->bs_state) {
-		/*
-		 * If state changed from UP to DOWN and we are in passive mode,
-		 * then * we need to disable the RX/TX timers to avoid sending
-		 * new control packets.
-		 */
-		if (bs->bs_passive
-		    && (ostate == STATE_UP && bs->bs_state == STATE_DOWN)) {
-			bfddp_callbacks.bc_rx_control_stop(bs, arg);
-			bfddp_callbacks.bc_tx_control_stop(bs, arg);
-		}
+	/* No state change, just return. */
+	if (ostate == bs->bs_state)
+		return;
 
-		bfddp_callbacks.bc_state_change(bs, arg, ostate, bs->bs_state);
+	/*
+	 * Call application callback to notify about state change.
+	 *
+	 * If state changed from UP to DOWN and we are in passive mode,
+	 * then * we need to disable the RX/TX timers to avoid sending
+	 * new control packets.
+	 */
+	if (bs->bs_passive
+	    && (ostate == STATE_UP && bs->bs_state == STATE_DOWN)) {
+		bfddp_callbacks.bc_rx_control_stop(bs, arg);
+		bfddp_callbacks.bc_tx_control_stop(bs, arg);
 	}
+
+	bfddp_callbacks.bc_state_change(bs, arg, ostate, bs->bs_state);
 }
 
 enum bfddp_packet_validation

--- a/libbfddp/bfddp_extra.h
+++ b/libbfddp/bfddp_extra.h
@@ -482,16 +482,6 @@ size_t bfddp_session_reply_counters(struct bfddp_ctx *bctx, uint16_t id,
  */
 
 /**
- * Converts host uint64_t to network uint64_t.
- */
-uint64_t hu64tonu64(uint64_t value);
-
-/**
- * Converts network uint64_t to host uint64_t.
- */
-uint64_t nu64tohu64(uint64_t value);
-
-/**
  * Generate next send interval timeout.
  *
  * \param bs the BFD session to get the negotiated intervals.

--- a/libbfddp/bfddp_extra.h
+++ b/libbfddp/bfddp_extra.h
@@ -466,10 +466,13 @@ uint64_t nu64tohu64(uint64_t value);
  * Generate next send interval timeout.
  *
  * \param bs the BFD session to get the negotiated intervals.
+ * \param add_jitter apply jitter to the calculated interval (usually this
+ * is required to avoid sessions packet synchronization).
  *
  * \returns interval until next transmission in microseconds.
  */
-uint32_t bfddp_session_next_control_tx_interval(struct bfd_session *bs);
+uint32_t bfddp_session_next_control_tx_interval(struct bfd_session *bs,
+						bool add_jitter);
 
 /**
  * Generate next receive expiration interval timeout.

--- a/libbfddp/bfddp_extra.h
+++ b/libbfddp/bfddp_extra.h
@@ -258,6 +258,7 @@ typedef void (*bfddp_rx_control_stop_cb)(struct bfd_session *bs, void *arg);
  * BFD state change: it is called every time the session state changes.
  *
  * \param bs the BFD session.
+ * \param arg application argument.
  * \param ostate the old BFD session state.
  * \param nstate the new BFD session state.
  */
@@ -306,12 +307,12 @@ void bfddp_initialize(struct bfddp_callbacks *bc);
  * Allocates a new session data structure with the information that came from
  * FRR's BFD daemon.
  *
- * \param bds the BFD message.
+ * \param bctx FRR BFD data plane to talk to.
  * \param arg application argument.
- * \param bctx the FRR BFD data plane to talk to.
+ * \param bds BFD session message contents.
  */
 struct bfd_session *bfddp_session_new(struct bfddp_ctx *bctx, void *arg,
-				      const struct bfddp_session *bm);
+				      const struct bfddp_session *bds);
 
 /**
  * Allocates a new session data structure with the information that came from
@@ -329,6 +330,7 @@ void bfddp_session_update(struct bfd_session *bs, void *arg,
  * FRR's BFD daemon.
  *
  * \param bs the BFD session.
+ * \param arg application argument.
  */
 void bfddp_session_free(struct bfd_session **bs, void *arg);
 
@@ -339,9 +341,8 @@ void bfddp_session_free(struct bfd_session **bs, void *arg);
  * \param bs the BFD session.
  * \param bcp the control packet buffer.
  */
-void
-bfddp_fill_control_packet(const struct bfd_session *bs,
-			  struct bfddp_control_packet *bcp);
+void bfddp_fill_control_packet(const struct bfd_session *bs,
+			       struct bfddp_control_packet *bcp);
 
 /**
  * Sends a control packet using the session current state for generating

--- a/libbfddp/bfddp_extra.h
+++ b/libbfddp/bfddp_extra.h
@@ -333,6 +333,17 @@ void bfddp_session_update(struct bfd_session *bs, void *arg,
 void bfddp_session_free(struct bfd_session **bs, void *arg);
 
 /**
+ * Fill the BFD control packet with the information present in the session data
+ * structure.
+ *
+ * \param bs the BFD session.
+ * \param bcp the control packet buffer.
+ */
+void
+bfddp_fill_control_packet(const struct bfd_session *bs,
+			  struct bfddp_control_packet *bcp);
+
+/**
  * Sends a control packet using the session current state for generating
  * the packet. Packet modifications and others may be done before sending
  * the packet with the `bfddp_tx_control` callback.

--- a/libbfddp/bfddp_extra.h
+++ b/libbfddp/bfddp_extra.h
@@ -403,6 +403,22 @@ enum bfddp_packet_validation
 bfddp_session_validate_packet(const struct bfddp_control_packet *bcp,
 			      size_t bcplen);
 
+/** BFD control packet session validation results. */
+enum bfddp_packet_validation_extra {
+	/** Everything is fine. */
+	BPVE_OK = 0,
+	/** Invalid remote ID (our ID) discriminator. */
+	BPVE_REMOTE_ID_INVALID,
+	/** Authentication set, but not configured. */
+	BPVE_UNEXPECTED_AUTH,
+	/** Multi bit set, but not configured. */
+	BPVE_UNEXPECTED_MULTI,
+	/** Authentication not set, but configured. */
+	BPVE_AUTH_MISSING,
+	/** Authentication set, configured but different. */
+	BPVE_AUTH_INVALID,
+};
+
 /**
  * Function that should be called when the session receives a control packet.
  *
@@ -410,8 +426,9 @@ bfddp_session_validate_packet(const struct bfddp_control_packet *bcp,
  * \param arg application argument.
  * \param bcp the BFD control packet.
  */
-void bfddp_session_rx_packet(struct bfd_session *bs, void *arg,
-			     const struct bfddp_control_packet *bcp);
+enum bfddp_packet_validation_extra
+bfddp_session_rx_packet(struct bfd_session *bs, void *arg,
+			const struct bfddp_control_packet *bcp);
 
 
 /*

--- a/libbfddp/bfddp_extra.h
+++ b/libbfddp/bfddp_extra.h
@@ -1,0 +1,483 @@
+/*
+ * BFD Data Plane library extra functions.
+ *
+ * Copyright (C) 2020 Network Device Education Foundation, Inc. ("NetDEF")
+ *                    Rafael F. Zalamena
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/**
+ * \file bfddp_extra.h
+ */
+#ifndef BFDDP_EXTRA_H
+#define BFDDP_EXTRA_H
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "bfddp.h"
+#include "bfddp_packet.h"
+
+/** The BFD session structure for holding information. */
+struct bfd_session {
+	/** Peer multiple hop indicator. */
+	bool bs_multihop;
+	/** Demand mode indicator. */
+	bool bs_demand;
+	/** Control Plane Independent indicator. */
+	bool bs_cbit;
+	/** Echo mode indicator. */
+	bool bs_echo;
+	/** Passive mode indicator. */
+	bool bs_passive;
+	/** BFD timers poll indicator. */
+	bool bs_poll;
+	/** BFD final indicator. */
+	bool bs_final;
+	/** BFD administrative shutdown state. */
+	bool bs_admin_shutdown;
+
+	/** IPv4 address indicator. */
+	bool bs_ipv4;
+	/** Local address. */
+	union {
+		struct sockaddr bs_src_sa;
+		struct sockaddr_in bs_src_sin;
+		struct sockaddr_in6 bs_src_sin6;
+	} bs_src;
+	/** Remote address. */
+	union {
+		struct sockaddr bs_dst_sa;
+		struct sockaddr_in bs_dst_sin;
+		struct sockaddr_in6 bs_dst_sin6;
+	} bs_dst;
+
+	/** Local discriminator. */
+	uint32_t bs_lid;
+	/** Remote discriminator. */
+	uint32_t bs_rid;
+
+	/** Desired minimum transmission interval. */
+	uint32_t bs_tx;
+	/** Current desired minimum transmission interval. */
+	uint32_t bs_cur_tx;
+	/** Required minimum receive interval. */
+	uint32_t bs_rx;
+	/** Current required minimum receive interval. */
+	uint32_t bs_cur_rx;
+	/** Required minimum echo receive interval. */
+	uint32_t bs_erx;
+	/** Current required minimum echo receive interval. */
+	uint32_t bs_cur_erx;
+	/** Milliseconds to wait before starting session. */
+	uint32_t bs_hold;
+	/** Detection multiplier. */
+	uint8_t bs_dmultiplier;
+	/** Currently used detection multiplier. */
+	uint8_t bs_cur_dmultiplier;
+
+	/** Minimum amount of TTL to expect. */
+	uint8_t bs_minttl;
+
+	/** Interface index. */
+	uint32_t bs_ifindex;
+	/** Interface name. */
+	char bs_ifname[64];
+
+	/** Local state. */
+	enum bfd_state_value bs_state;
+	/** Local diagnostic. */
+	enum bfd_diagnostic_value bs_diag;
+	/** Remote state. */
+	enum bfd_state_value bs_rstate;
+	/** Remote diagnostic. */
+	enum bfd_diagnostic_value bs_rdiag;
+
+	/** Remote Control Plane Independent bit value. */
+	bool bs_rcbit;
+	/** Remote Demand mode bit value. */
+	bool bs_rdemand;
+
+	/** Remote desired minimum transmission interval. */
+	uint32_t bs_rtx;
+	/** Remote required minimum receive interval. */
+	uint32_t bs_rrx;
+	/** Remote required minimum echo receive interval. */
+	uint32_t bs_rerx;
+	/** Remote detection multiplier. */
+	uint8_t bs_rdmultiplier;
+
+	/** Session control packet input counter. */
+	uint64_t bs_crx_bytes;
+	/** Session control packet bytes input counter. */
+	uint64_t bs_crx_packets;
+	/** Session control packet output counter. */
+	uint64_t bs_ctx_bytes;
+	/** Session control packet bytes output counter. */
+	uint64_t bs_ctx_packets;
+
+	/** Data plane context we belong to. */
+	struct bfddp_ctx *bs_bctx;
+
+	/** Implementation dependent data. */
+	void *bs_data;
+};
+
+
+/*
+ * Callbacks.
+ */
+
+/**
+ * BFD session creation callback: use it to attach your application data
+ * to session without adding boiler plate code. Use `bs_data` to store your
+ * private data.
+ *
+ * The session will contain no configuration, use `bfddp_session_update_cb`
+ * callback to handle configuration changes.
+ *
+ * Return failure if something fatal happened to avoid moving forward with the
+ * session setup.
+ *
+ * \param bs the newly create BFD session (empty/no configurations).
+ * \param arg application argument.
+ *
+ * \returns `-1` on failure otherwise `0`.
+ */
+typedef int (*bfddp_session_new_cb)(struct bfd_session *bs, void *arg);
+
+/**
+ * BFD session update callback: called every time FRR BFD updates the
+ * session configurations.
+ *
+ * The appropriated timers callback will be called depending on the
+ * configuration coming from FRR: shutdown disables all timers, passive
+ * disables timer if the session is down and so on.
+ *
+ * \param bs the updated BFD session.
+ * \param arg application argument.
+ */
+typedef void (*bfddp_session_update_cb)(struct bfd_session *bs, void *arg);
+
+/**
+ * BFD session deletion callback: use it to detach your application data from
+ * session.
+ *
+ * \param bs BFD session being removed.
+ * \param arg application argument.
+ */
+typedef void (*bfddp_session_free_cb)(struct bfd_session *bs, void *arg);
+
+/**
+ * BFD control packet transmission callback. Implements the lower level
+ * details of sending the packet (e.g. using a socket or writing into hardware
+ * memory).
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ * \param bcp the BFD control packet ready to be sent.
+ *
+ * \returns `-1` or `0` on failure otherwise the number of bytes to account.
+ */
+typedef ssize_t (*bfddp_tx_control_cb)(struct bfd_session *bs, void *arg,
+				       const struct bfddp_control_packet *bcp);
+
+/**
+ * Add or update session control packet transmission timer.
+ *
+ * This is called when the BFD protocol state machine requires the packet to be
+ * transmitted and start a transmission timer. It will only be called again to
+ * update the transmission timers to a new negotiated interval.
+ *
+ * The packet sending and retriggering of the timer must be done by the
+ * application since the library has no knowledge about timers.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ */
+typedef void (*bfddp_tx_control_update_cb)(struct bfd_session *bs, void *arg);
+
+/**
+ * Stop session control packet transmission timer.
+ *
+ * This is called when the BFD protocol state machine wants to stop
+ * transmitting new control packets.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ */
+typedef void (*bfddp_tx_control_stop_cb)(struct bfd_session *bs, void *arg);
+
+/**
+ * Add or update session receive control packet timer.
+ *
+ * This is called every time the state machine wants to know if a control
+ * packet timeout will expire. This function will be called often, basically
+ * every time the application receives a BFD control packet with
+ * `bfddp_session_rx_packet`.
+ *
+ * The application must call `bfddp_session_rx_timeout` if the timer expired.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ */
+typedef void (*bfddp_rx_control_update_cb)(struct bfd_session *bs, void *arg);
+
+/**
+ * Stop session receive control packet timer.
+ *
+ * This is called when the BFD protocol state machine wants to stop receiving
+ * `bfddp_session_rx_timeout` notifications.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ */
+typedef void (*bfddp_rx_control_stop_cb)(struct bfd_session *bs, void *arg);
+
+/**
+ * BFD state change: it is called every time the session state changes.
+ *
+ * \param bs the BFD session.
+ * \param ostate the old BFD session state.
+ * \param nstate the new BFD session state.
+ */
+typedef void (*bfddp_state_change_cb)(struct bfd_session *bs, void *arg,
+				      enum bfd_state_value ostate,
+				      enum bfd_state_value nstate);
+
+/** The BFD data plane callbacks.  */
+struct bfddp_callbacks {
+	/** Optional callback. */
+	bfddp_session_new_cb bc_session_new;
+	/** Optional callback. */
+	bfddp_session_update_cb bc_session_update;
+	/** Optional callback. */
+	bfddp_session_free_cb bc_session_free;
+
+	/** Mandatory callback. */
+	bfddp_tx_control_cb bc_tx_control;
+	/** Mandatory callback. */
+	bfddp_tx_control_update_cb bc_tx_control_update;
+	/** Mandatory callback. */
+	bfddp_tx_control_stop_cb bc_tx_control_stop;
+
+	/** Mandatory callback. */
+	bfddp_rx_control_update_cb bc_rx_control_update;
+	/** Mandatory callback. */
+	bfddp_rx_control_stop_cb bc_rx_control_stop;
+
+	/** Optional callback. */
+	bfddp_state_change_cb bc_state_change;
+};
+
+/**
+ * Set the library callbacks.
+ *
+ * \param bc the callbacks structure filled.
+ */
+void bfddp_initialize(struct bfddp_callbacks *bc);
+
+
+/*
+ * BFD implementation functions.
+ */
+
+/**
+ * Allocates a new session data structure with the information that came from
+ * FRR's BFD daemon.
+ *
+ * \param bds the BFD message.
+ * \param arg application argument.
+ * \param bctx the FRR BFD data plane to talk to.
+ */
+struct bfd_session *bfddp_session_new(struct bfddp_ctx *bctx, void *arg,
+				      const struct bfddp_session *bm);
+
+/**
+ * Allocates a new session data structure with the information that came from
+ * FRR's BFD daemon.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ * \param bds the BFD message.
+ */
+void bfddp_session_update(struct bfd_session *bs, void *arg,
+			  const struct bfddp_session *bds);
+
+/**
+ * Allocates a new session data structure with the information that came from
+ * FRR's BFD daemon.
+ *
+ * \param bs the BFD session.
+ */
+void bfddp_session_free(struct bfd_session **bs, void *arg);
+
+/**
+ * Sends a control packet using the session current state for generating
+ * the packet. Packet modifications and others may be done before sending
+ * the packet with the `bfddp_tx_control` callback.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ *
+ * \returns the callback return value.
+ */
+ssize_t bfddp_send_control_packet(struct bfd_session *bs, void *arg);
+
+/**
+ * Function that should be called when the session receive timer expires.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ */
+void bfddp_session_rx_timeout(struct bfd_session *bs, void *arg);
+
+/**
+ * Call this function when you want to change the peer state.
+ *
+ * \param bs the BFD session to change state.
+ * \param arg application argument.
+ * \param nstate new session state.
+ */
+void bfddp_session_state_machine(struct bfd_session *bs, void *arg,
+				 enum bfd_state_value nstate);
+
+/** BFD initial packet validation. */
+enum bfddp_packet_validation {
+	/** Packet is valid. */
+	BPV_OK = 0,
+	/** Received packet is too small. */
+	BPV_PACKET_TOO_SMALL,
+	/** Invalid BFD header version field. */
+	BPV_INVALID_VERSION,
+	/** Packet header length has invalid value. */
+	BPV_INVALID_LENGTH,
+	/** Detection multiplier is set to zero. */
+	BPV_ZERO_MULTIPLIER,
+	/** Local ID (the peer's ID) is set to zero. */
+	BPV_ZERO_LOCAL_ID,
+	/** State is INIT or UP, but the remote system hasn't learned our ID. */
+	BPV_INVALID_REMOTE_ID,
+};
+
+/**
+ * Validate the packet before attempting to access its fields.
+ *
+ * \param bcp the packet binary.
+ * \param bcplen the packet binary size.
+ *
+ * \returns one of the values of `bfddp_packet_validation`.
+ */
+enum bfddp_packet_validation
+bfddp_session_validate_packet(const struct bfddp_control_packet *bcp,
+			      size_t bcplen);
+
+/**
+ * Function that should be called when the session receives a control packet.
+ *
+ * \param bs the BFD session.
+ * \param arg application argument.
+ * \param bcp the BFD control packet.
+ */
+void bfddp_session_rx_packet(struct bfd_session *bs, void *arg,
+			     const struct bfddp_control_packet *bcp);
+
+
+/*
+ * Control plane helper functions.
+ */
+
+/**
+ * Send echo request to control plane.
+ *
+ * \param bctx the FRR BFD control plane to talk to.
+ *
+ * \returns `bfddp_write_enqueue` result.
+ */
+size_t bfddp_send_echo_request(struct bfddp_ctx *bctx);
+
+/**
+ * Send echo reply to control plane.
+ *
+ * \param bctx the FRR BFD control plane to talk to.
+ * \param bfdd_time the FRR BFD time it measured.
+ *
+ * \returns `bfddp_write_enqueue` result.
+ */
+size_t bfddp_send_echo_reply(struct bfddp_ctx *bctx, uint64_t bfdd_time);
+
+/**
+ * Send session state change to control plane.
+ *
+ * \param bs the BFD session.
+ *
+ * \returns `bfddp_write_enqueue` result.
+ */
+size_t bfddp_send_session_state_change(const struct bfd_session *bs);
+
+/**
+ * Send session counters in reply to control plane.
+ *
+ * \param bctx the FRR BFD control plane to talk to.
+ * \param id the message ID to reply to.
+ * \param bs the BFD session (may be `NULL` if not found).
+ *
+ * \returns `bfddp_write_enqueue` result.
+ */
+size_t bfddp_session_reply_counters(struct bfddp_ctx *bctx, uint16_t id,
+				    const struct bfd_session *bs);
+
+
+/*
+ * Misc functions.
+ */
+
+/**
+ * Converts host uint64_t to network uint64_t.
+ */
+uint64_t hu64tonu64(uint64_t value);
+
+/**
+ * Converts network uint64_t to host uint64_t.
+ */
+uint64_t nu64tohu64(uint64_t value);
+
+/**
+ * Generate next send interval timeout.
+ *
+ * \param bs the BFD session to get the negotiated intervals.
+ *
+ * \returns interval until next transmission in microseconds.
+ */
+uint32_t bfddp_session_next_control_tx_interval(struct bfd_session *bs);
+
+/**
+ * Generate next receive expiration interval timeout.
+ *
+ * \param bs the BFD session to get the negotiated intervals.
+ *
+ * \returns interval until next receive expiration in microseconds.
+ */
+uint32_t bfddp_session_next_control_rx_interval(struct bfd_session *bs);
+
+#endif /* BFDDP_EXTRA_H */

--- a/libbfddp/bfddp_packet.h
+++ b/libbfddp/bfddp_packet.h
@@ -62,6 +62,19 @@
 #define SLOWSTART_ERX 0u
 
 /*
+ * Definitions of percentage for maximum allowed jitter value for transmission
+ * of control packets. This is needed in order to avoid session
+ * synchronization.
+ *
+ * See RFC 5880 Section 6.8.7. Transmitting BFD Control Packets.
+ */
+
+/** Maximum jitter percentage for detection multiplier == 1. */
+#define BFD_DM_ONE_MAX_JITTER 10
+/** Maximum jitter percentage for detection multiplier > 1. */
+#define BFD_DM_MAX_JITTER 25
+
+/*
  * BFD single hop source UDP ports. As defined in RFC 5881 Section 4.
  * Encapsulation.
  */

--- a/libbfddp/bfddp_packet.h
+++ b/libbfddp/bfddp_packet.h
@@ -43,6 +43,9 @@
  */
 #define BFD_PROTOCOL_VERSION 1
 
+/** Default data plane port. */
+#define BFD_DATA_PLANE_DEFAULT_PORT 50700
+
 /** BFD single hop UDP port, as defined in RFC 5881 Section 4. Encapsulation. */
 #define BFD_SINGLE_HOP_PORT 3784
 
@@ -93,10 +96,10 @@ enum bfddp_message_type {
  * Data plane might use whatever precision it wants for `dp_time`
  * field, however if you want to be able to tell the delay between
  * data plane packet send and BFD daemon packet processing you should
- * use `gettimeofday()` and have the data plane clock sincronized with
+ * use `gettimeofday()` and have the data plane clock synchronized with
  * BFD daemon (not a problem if data plane runs in the same system).
  *
- * Normally data plane will only check the timestamp it sent to determine
+ * Normally data plane will only check the time stamp it sent to determine
  * the whole packet trip time.
  */
 struct bfddp_echo {
@@ -109,7 +112,7 @@ struct bfddp_echo {
 
 /** BFD session flags. */
 enum bfddp_session_flag {
-	/** Set when using multihop. */
+	/** Set when using multi hop. */
 	SESSION_MULTIHOP = (1 << 0),
 	/** Set when using demand mode. */
 	SESSION_DEMAND = (1 << 1),
@@ -164,10 +167,7 @@ struct bfddp_session {
 	 * without jitter.
 	 */
 	uint32_t min_echo_rx;
-	/**
-	 * Amount of milliseconds to wait before starting sending session
-	 * packets (only works when `SESSION_PASSIVE` flag is not set).
-	 */
+	/** Amount of milliseconds to wait before starting the session */
 	uint32_t hold_time;
 
 	/** Minimum TTL. */
@@ -257,14 +257,11 @@ struct bfddp_state_change {
  * BFD control packet state bits definition.
  */
 enum bfddp_control_state_bits {
-	/** Used to request connection establishement signal. */
+	/** Used to request connection establishment signal. */
 	STATE_POLL_BIT = (1 << 5),
-	/** Finalizes the connection establishement signal. */
+	/** Finalizes the connection establishment signal. */
 	STATE_FINAL_BIT = (1 << 4),
-	/**
-	 * Signalizes that the peer forward plane doesn't depend on control
-	 * plane.
-	 */
+	/** Signalizes that forward plane doesn't depend on control plane. */
 	STATE_CPI_BIT = (1 << 3),
 	/** Signalizes the use of authentication. */
 	STATE_AUTH_BIT = (1 << 2),
@@ -296,11 +293,11 @@ struct bfddp_control_packet {
 	uint32_t local_id;
 	/** Remote system discriminator. */
 	uint32_t remote_id;
-	/** Desired minimun send interval in microseconds. */
+	/** Desired minimum send interval in microseconds. */
 	uint32_t desired_tx;
-	/** Desired minimun receive interval in microseconds. */
+	/** Desired minimum receive interval in microseconds. */
 	uint32_t required_rx;
-	/** Desired minimun echo receive interval in microseconds. */
+	/** Desired minimum echo receive interval in microseconds. */
 	uint32_t required_echo_rx;
 };
 

--- a/libbfddp/bfddp_packet.h
+++ b/libbfddp/bfddp_packet.h
@@ -301,6 +301,26 @@ struct bfddp_control_packet {
 	uint32_t required_echo_rx;
 };
 
+/** helper function to standardize state bits reading. */
+static inline uint8_t __attribute__((always_inline))
+bfddp_read_control_packet_version(const struct bfddp_control_packet *bcp)
+{
+	return (bcp->version_diag >> 5) & 0x07;
+}
+
+static inline uint8_t __attribute__((always_inline))
+bfddp_read_control_packet_diagnostic(const struct bfddp_control_packet *bcp)
+{
+	return bcp->version_diag & 0x1F;
+}
+
+/** helper function to standardize state bits reading. */
+static inline uint8_t __attribute__((always_inline))
+bfddp_read_control_packet_state(const struct bfddp_control_packet *bcp)
+{
+	return bcp->state_bits >> 6;
+}
+
 /**
  * The protocol wire message header structure.
  */

--- a/libbfddp/bfddp_packet.h
+++ b/libbfddp/bfddp_packet.h
@@ -141,6 +141,9 @@ enum bfddp_session_flag {
 	SESSION_SHUTDOWN = (1 << 6),
 };
 
+/** Interface name theoretical maximum size. */
+#define BFDDP_INTERFACE_MAX_SIZE 64
+
 /**
  * `DP_ADD_SESSION`/`DP_DELETE_SESSION` data payload.
  *
@@ -193,7 +196,7 @@ struct bfddp_session {
 	/** Interface index (set to `0` when unavailable). */
 	uint32_t ifindex;
 	/** Interface name (empty when unavailable). */
-	char ifname[64];
+	char ifname[BFDDP_INTERFACE_MAX_SIZE];
 
 	/* TODO: missing authentication. */
 };

--- a/libbfddp/bfddp_packet.h
+++ b/libbfddp/bfddp_packet.h
@@ -52,6 +52,9 @@
 /** BFD multi hop UDP port, as defined in RFC 5883 Section 5. Encapsulation. */
 #define BFD_MULTI_HOP_PORT 4784
 
+/** BFD echo UDP port, as defined in RFC 5881 Section 4. Encapsulation. */
+#define BFD_ECHO_PORT 3785
+
 /** Default slow start multiplier. */
 #define SLOWSTART_DMULT 3
 /** Default slow start transmission speed. */

--- a/libbfddp/bfddp_packet.h
+++ b/libbfddp/bfddp_packet.h
@@ -33,6 +33,38 @@
 
 #include <stdint.h>
 
+/*
+ * Protocol definitions.
+ */
+
+/**
+ * BFD protocol version as defined in RFC5880 Section 4.1 Generic BFD Control
+ * Packet Format.
+ */
+#define BFD_PROTOCOL_VERSION 1
+
+/** BFD single hop UDP port, as defined in RFC 5881 Section 4. Encapsulation. */
+#define BFD_SINGLE_HOP_PORT 3784
+
+/** BFD multi hop UDP port, as defined in RFC 5883 Section 5. Encapsulation. */
+#define BFD_MULTI_HOP_PORT 4784
+
+/** Default slow start multiplier. */
+#define SLOWSTART_DMULT 3
+/** Default slow start transmission speed. */
+#define SLOWSTART_TX 1000000u
+/** Default slow start receive speed. */
+#define SLOWSTART_RX 1000000u
+/** Default slow start echo receive speed. */
+#define SLOWSTART_ERX 0u
+
+/*
+ * BFD single hop source UDP ports. As defined in RFC 5881 Section 4.
+ * Encapsulation.
+ */
+#define BFD_SOURCE_PORT_BEGIN 49152
+#define BFD_SOURCE_PORT_END 65535
+
 /** BFD data plane protocol version. */
 #define BFD_DP_VERSION 1
 
@@ -89,6 +121,8 @@ enum bfddp_session_flag {
 	SESSION_IPV6 = (1 << 4),
 	/** Set when using passive mode. */
 	SESSION_PASSIVE = (1 << 5),
+	/** Set when session is administrative down. */
+	SESSION_SHUTDOWN = (1 << 6),
 };
 
 /**

--- a/soft_bfddpd/bfddpd.c
+++ b/soft_bfddpd/bfddpd.c
@@ -150,6 +150,11 @@ parse_address(const char *arg, struct sockaddr *sa, socklen_t *salen)
 
 	/* Copy type string. */
 	sptr++;
+
+	/* Check if type is strangely long. */
+	if (slen >= sizeof(type))
+		errx(1, "%s: type is too long: %zu characters", __func__, slen);
+
 	memcpy(type, arg, slen);
 	type[slen] = 0;
 

--- a/soft_bfddpd/bfddpd.c
+++ b/soft_bfddpd/bfddpd.c
@@ -25,19 +25,12 @@
 
 #include <arpa/inet.h>
 #include <sys/poll.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
 #include <sys/un.h>
 
 #include <err.h>
 #include <errno.h>
-#include <poll.h>
 #include <signal.h>
-#include <stdbool.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
 #include <unistd.h>
 
 #include "bfddp.h"

--- a/soft_bfddpd/bfddpd.c
+++ b/soft_bfddpd/bfddpd.c
@@ -170,7 +170,7 @@ parse_address(const char *arg, struct sockaddr *sa, socklen_t *salen)
 		/* Parse port if any. */
 		sptr = strchr(sptr, ':');
 		if (sptr == NULL) {
-			sin->sin_port = htons(3000);
+			sin->sin_port = htons(BFD_DATA_PLANE_DEFAULT_PORT);
 		} else {
 			*sptr = 0;
 			sin->sin_port = htons(parse_port(sptr + 1));
@@ -185,7 +185,7 @@ parse_address(const char *arg, struct sockaddr *sa, socklen_t *salen)
 		/* Parse port if any. */
 		sptr = strrchr(sptr, ':');
 		if (sptr == NULL) {
-			sin6->sin6_port = htons(3000);
+			sin6->sin6_port = htons(BFD_DATA_PLANE_DEFAULT_PORT);
 		} else {
 			*sptr = 0;
 			sin6->sin6_port = htons(parse_port(sptr + 1));

--- a/soft_bfddpd/bfddpd.h
+++ b/soft_bfddpd/bfddpd.h
@@ -284,30 +284,6 @@ void bfd_recv_control_packet(int sock);
 #define slog(fmt, args...) /* empty */
 #endif /* SESSION_DEBUG */
 
-/** BFD single hop UDP port, as defined in RFC 5881 Section 4. Encapsulation. */
-#define BFD_SINGLE_HOP_PORT 3784
-
-/* BFD single hop echo UDP port, as defind in RFC 5881 Section 4. Encapsulation. */
-#define BFD_SINGLE_HOP_ECHO_PORT 3785
-
-/** BFD multi hop UDP port, as defined in RFC 5883 Section 5. Encapsulation. */
-#define BFD_MULTI_HOP_PORT 4784
-
-/** BFD protocol version, as defind in RFC5880 Section 4.1 Generic BFD Control Packet Format. */
-#define BFD_PROTOCOL_VERSION 1
-
-#define SLOWSTART_DMULT 3
-#define SLOWSTART_TX 1000000u
-#define SLOWSTART_RX 1000000u
-#define SLOWSTART_ERX 0u
-
-/*
- * BFD single hop source UDP ports. As defined in RFC 5881 Section 4.
- * Encapsulation.
- */
-#define BFD_SOURCE_PORT_BEGIN 49152
-#define BFD_SOURCE_PORT_END 65535
-
 struct bfd_error_statistics {
 	/** Number of packets with invalid length */
 	uint64_t invalid_len_drops;

--- a/soft_bfddpd/bfddpd.h
+++ b/soft_bfddpd/bfddpd.h
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 
 #include "bfddp.h"
+#include "bfddp_extra.h"
 
 #include "openbsd-tree.h"
 
@@ -233,22 +234,7 @@ void events_ctx_del_timer(struct events_ctx *ec, struct timer_ctx **tc);
 #endif /* PACKET_DEBUG */
 
 /* FRR protocol packets. */
-void bfddp_send_echo_request(struct bfddp_ctx *bctx);
-void bfddp_send_echo_reply(struct bfddp_ctx *bctx, uint64_t bfdd_time);
 void bfddp_process_echo_time(const struct bfddp_echo *echo);
-void bfddp_send_session_state_change(const struct bfd_session *bs);
-
-/**
- * Sends back to BFD daemon the updated session counters.
- *
- * \param bctx the data plane context to return answer.
- * \param msg the request message.
- */
-int bfd_session_reply_counters(struct bfddp_ctx *bctx,
-			       const struct bfddp_message *msg);
-
-/* BFD Protocol packets. */
-void bfd_send_control_packet(struct bfd_session *bs);
 
 /** Packet read data+metadata. */
 struct bfd_packet_metadata {
@@ -275,6 +261,10 @@ struct bfd_packet_metadata {
  */
 void bfd_recv_control_packet(int sock);
 
+/** BFD packet sending callback implementation. */
+ssize_t bfd_tx_control_cb(struct bfd_session *bs, void *arg,
+			  const struct bfddp_control_packet *bcp);
+
 /*
  * session.c
  */
@@ -299,117 +289,25 @@ struct bfd_error_statistics {
 	uint64_t invalid_session_drops;
 };
 
-struct bfd_session {
+struct bfd_session_data {
 	/** Events context pointer for scheduling timers/fds. */
-	struct events_ctx *bs_ec;
-	/** BFD Data Plane context for talking with FRR. */
-	struct bfddp_ctx *bs_bctx;
+	struct events_ctx *bsd_ec;
 
 	/** BFD Control packet transmission timeout event. */
-	struct timer_ctx *bs_txev;
+	struct timer_ctx *bsd_txev;
 	/** BFD Control packet receive timeout event. */
-	struct timer_ctx *bs_rxev;
-
-	/** Peer multiple hop indicator. */
-	bool bs_multihop;
-	/** Demand mode indicator. */
-	bool bs_demand;
-	/** Control Plane Indenpendant indicator. */
-	bool bs_cbit;
-	/** Echo mode indicator. */
-	bool bs_echo;
-	/** Passive mode indicator. */
-	bool bs_passive;
-	/** BFD timers poll indicator. */
-	bool bs_poll;
-	/** BFD final indicator. */
-	bool bs_final;
-
-	/** IPv4 address indicator. */
-	bool bs_ipv4;
-	/** Local address. */
-	union {
-		struct sockaddr bs_src_sa;
-		struct sockaddr_in bs_src_sin;
-		struct sockaddr_in6 bs_src_sin6;
-	} bs_src;
-	/** Remote address. */
-	union {
-		struct sockaddr bs_dst_sa;
-		struct sockaddr_in bs_dst_sin;
-		struct sockaddr_in6 bs_dst_sin6;
-	} bs_dst;
-
-	/** Local discriminator. */
-	uint32_t bs_lid;
-	/** Remote discriminator. */
-	uint32_t bs_rid;
-
-	/** Desired minimum transmission interval. */
-	uint32_t bs_tx;
-	/** Current desired minimum transmission interval. */
-	uint32_t bs_cur_tx;
-	/** Required minimum receive interval. */
-	uint32_t bs_rx;
-	/** Current required minimum receive interval. */
-	uint32_t bs_cur_rx;
-	/** Required minimum echo receive interval. */
-	uint32_t bs_erx;
-	/** Current required minimum echo receive interval. */
-	uint32_t bs_cur_erx;
-	/** Milliseconds to wait before starting session. */
-	uint32_t bs_hold;
-	/** Detection multipler. */
-	uint8_t bs_dmultiplier;
-	/** Currently used detection multipler. */
-	uint8_t bs_cur_dmultiplier;
-
-	/** Minimum amount of TTL to expect. */
-	uint8_t bs_minttl;
-
-	/** Interface index. */
-	uint32_t bs_ifindex;
-	/** Interface name. */
-	char bs_ifname[64];
-
-	/** Local state. */
-	enum bfd_state_value bs_state;
-	/** Local diagnostic. */
-	enum bfd_diagnostic_value bs_diag;
-	/** Remote state. */
-	enum bfd_state_value bs_rstate;
-	/** Remote diagnostic. */
-	enum bfd_diagnostic_value bs_rdiag;
-
-	/** Remote Control Plane Independent bit value. */
-	bool bs_rcbit;
-	/** Remote Demand mode bit value. */
-	bool bs_rdemand;
-
-	/** Remote desired minimum transmission interval. */
-	uint32_t bs_rtx;
-	/** Remote required minimum receive interval. */
-	uint32_t bs_rrx;
-	/** Remote required minimum echo receive interval. */
-	uint32_t bs_rerx;
-	/** Remote detection multipler. */
-	uint8_t bs_rdmultiplier;
+	struct timer_ctx *bsd_rxev;
 
 	/** Session socket. */
-	int bs_sock;
+	int bsd_sock;
 
-	/** Session control packet bytes input counter. */
-	uint64_t bs_crx_bytes;
-	/** Session control packet input counter. */
-	uint64_t bs_crx_packets;
-	/** Session control packet bytes output counter. */
-	uint64_t bs_ctx_bytes;
-	/** Session control packet output counter. */
-	uint64_t bs_ctx_packets;
+	/** Back pointer to BFD session data. */
+	struct bfd_session *bsd_bs;
+
 	/** Number of times this session went UP */
-	uint64_t bs_up_count;
+	uint64_t bsd_up_count;
 	/** Number of times this session went DOWN */
-	uint64_t bs_down_count;
+	uint64_t bsd_down_count;
 
 	RBT_ENTRY(bfd_session) entry;
 };
@@ -423,34 +321,6 @@ void bfd_session_init(void);
  * Session internal data structures tear down.
  */
 void bfd_session_finish(void);
-
-/**
- * Creates a new BFD session and associates it with the event context `ec`,
- * the FRR BFD instance `bctx` and use the FRR's BFD message
- *
- * \param ec the event context that will handle the session events.
- * \param bctx the FRR BFD data plane to talk to.
- * \param bdps the FRR's BFD message with session information.
- */
-struct bfd_session *bfd_session_new(struct events_ctx *ec,
-				    struct bfddp_ctx *bctx,
-				    const struct bfddp_session *bdps);
-
-/**
- * Update BFD session parameters using FRR's BFD message.
- *
- * \param bs the BFD session.
- * \param bdps FRR's BFD message.
- */
-void bfd_session_update(struct bfd_session *bs,
-			const struct bfddp_session *bdps);
-
-/**
- * Deletes BFD session using FRR's BFD message information.
- *
- * \param bdps FRR's BFD message.
- */
-void bfd_session_delete(const struct bfddp_session *bdps);
 
 /**
  * Look up session using discriminator.
@@ -477,30 +347,6 @@ bfd_session_lookup_by_packet(const struct bfd_packet_metadata *bpm);
  */
 void bfd_session_state_machine(struct bfd_session *bs,
 			       enum bfd_state_value nstate);
-
-/**
- * This function should be called everytime a control packet is received,
- * it will update the control packet expiration timer.
- *
- * \param bs the BFD session.
- */
-void bfd_session_update_control_rx(struct bfd_session *bs);
-
-/**
- * Update transmission timer: call this function when the local desired
- * transmission interval or the remote minimum receive interval changes.
- *
- * \param bs the BFD session.
- */
-void bfd_session_update_control_tx(struct bfd_session *bs);
-
-/**
- * This function should be called everytime a control packet is received
- * with the final bit.
- *
- * \param bs the BFD session.
- */
-void bfd_session_final_event(struct bfd_session *bs);
 
 /**
  * Generate a random number.

--- a/soft_bfddpd/bfddpd.h
+++ b/soft_bfddpd/bfddpd.h
@@ -92,23 +92,12 @@ struct timer_ctx
 #endif /* DOXYGEN_DOC */
 ;
 
-/**
- * Events context poll callbacks.
- *
- * Return `-1` to remove file descriptor from events context or the events you
- * want to watch now (e.g. `POLLIN`, `POLLOUT`).
- */
-typedef int (*events_ctx_cb)(struct events_ctx *ec, int fd, short revents,
-			     void *arg);
+/** Events context poll callbacks. */
+typedef void (*events_ctx_cb)(struct events_ctx *ec, int fd, short revents,
+			      void *arg);
 
-/**
- * Events context timer poll callbacks.
- *
- * Return `-1` to remove timer from events context or `N` (where `N` >= 0)
- * to schedule it again with the same parameters and next time out in `N`
- * milliseconds.
- */
-typedef int64_t (*events_ctx_timer_cb)(struct events_ctx *ec, void *arg);
+/** Events context timer poll callbacks. */
+typedef void (*events_ctx_timer_cb)(struct events_ctx *ec, void *arg);
 
 /**
  * Allocates events context data structure to be used with `bfddp_poll`.
@@ -223,6 +212,14 @@ struct timer_ctx *events_ctx_update_timer(struct events_ctx *ec,
  * \see events_ctx_update_timer, events_ctx_timer_cb.
  */
 void events_ctx_del_timer(struct events_ctx *ec, struct timer_ctx **tc);
+
+/**
+ * Mark timer for manual removal only: if `events_ctx_del_timer` is not called
+ * you'll have a memory leak in your hands.
+ *
+ * \param tc the timer to mark.
+ */
+void events_ctx_keep_timer(struct timer_ctx *tc);
 
 /*
  * packet.c

--- a/soft_bfddpd/debug.c
+++ b/soft_bfddpd/debug.c
@@ -28,8 +28,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#include "bfddp.h"
-#include "bfddp_packet.h"
 #include "bfddpd.h"
 
 static const char *bfd_session_states[] = {

--- a/soft_bfddpd/debug.c
+++ b/soft_bfddpd/debug.c
@@ -64,7 +64,7 @@ bfd_session_debug(const struct bfd_session *bs, const char *fmt, ...)
 	int af = bs->bs_dst.bs_dst_sa.sa_family;
 	va_list vl;
 	uint16_t sport = 0, dport = 0;
-	char sbuf[INET6_ADDRSTRLEN], dbuf[INET6_ADDRSTRLEN];
+	char sbuf[INET6_ADDRSTRLEN] = {}, dbuf[INET6_ADDRSTRLEN] = {};
 	char msg[512];
 
 	switch (af) {
@@ -108,7 +108,6 @@ bfd_session_debug(const struct bfd_session *bs, const char *fmt, ...)
 void
 bfd_session_dump(const struct bfd_session *bs)
 {
-
 	bfd_session_debug(
 		bs, "%s%s%s%stx,rx,erx[%u,%u,%u r:%u,%u,%u] multi[%d, r:%d]",
 		bs->bs_passive ? "passive " : "",

--- a/soft_bfddpd/events.c
+++ b/soft_bfddpd/events.c
@@ -176,7 +176,7 @@ events_ctx_add_fd(struct events_ctx *ec, int fd, short events,
 
 	/* Search for subscribed `fd`. */
 	for (i = 0; i < ec->ec_pfds_used; i++) {
-		if (ec->ec_pfds->fd != fd)
+		if (ec->ec_pfds[i].fd != fd)
 			continue;
 
 		pfdc = &ec->ec_pfdcs[i];
@@ -222,6 +222,8 @@ events_ctx_del_fd(struct events_ctx *ec, int fd)
 
 	/* Now we must fill the gap created by the removal. */
 	remaining = (ec->ec_pfds_used - 1) - i;
+	/* Decrement the amount of file descriptors used. */
+	ec->ec_pfds_used -= 1;
 	/* Nothing to move. */
 	if (remaining == 0)
 		return;

--- a/soft_bfddpd/events.c
+++ b/soft_bfddpd/events.c
@@ -26,12 +26,10 @@
 /* Required from PRIu64 macro. */
 #include <inttypes.h>
 
-#include <errno.h>
-#include <poll.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/poll.h>
+
+#include <errno.h>
+#include <string.h>
 #include <time.h>
 
 #include "openbsd-tree.h"

--- a/soft_bfddpd/packet.c
+++ b/soft_bfddpd/packet.c
@@ -46,8 +46,8 @@ bfddp_process_echo_time(const struct bfddp_echo *echo)
 	struct timeval tv;
 
 	/* Collect registered timestamps. */
-	bfdt = nu64tohu64(echo->bfdd_time);
-	dpt = nu64tohu64(echo->dp_time);
+	bfdt = be64toh(echo->bfdd_time);
+	dpt = be64toh(echo->dp_time);
 
 	/* Measure new time. */
 	gettimeofday(&tv, NULL);

--- a/soft_bfddpd/packet.c
+++ b/soft_bfddpd/packet.c
@@ -26,11 +26,8 @@
 /* Required from PRIu64 macro. */
 #include <inttypes.h>
 
-#include <netinet/in.h>
-#include <sys/socket.h>
 #include <sys/time.h>
 
-#include <err.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>

--- a/soft_bfddpd/session.c
+++ b/soft_bfddpd/session.c
@@ -23,22 +23,13 @@
  * IN THE SOFTWARE.
  */
 
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-
-#include <errno.h>
 #include <fcntl.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
 
 #include "bfddp_extra.h"
 #include "bfddpd.h"
-
-#include "openbsd-tree.h"
 
 /*
  * BFD Session data structure handling.

--- a/soft_bfddpd/session.c
+++ b/soft_bfddpd/session.c
@@ -443,10 +443,10 @@ bfd_session_lookup_by_packet(const struct bfd_packet_metadata *bpm)
 				continue;
 		}
 
-		break;
+		return bs;
 	}
 
-	return bs;
+	return NULL;
 }
 
 uint32_t

--- a/soft_bfddpd/session.c
+++ b/soft_bfddpd/session.c
@@ -269,12 +269,12 @@ bfd_session_update_control_tx(struct bfd_session *bs,
 	if (bsd->bsd_txev)
 		bsd->bsd_txev = events_ctx_update_timer(
 			bsd->bsd_ec, bsd->bsd_txev,
-			bfddp_session_next_control_tx_interval(bs) / 1000,
+			bfddp_session_next_control_tx_interval(bs, true) / 1000,
 			bfd_session_control_tx_timeout, bs);
 	else {
 		bsd->bsd_txev = events_ctx_add_timer(
 			bsd->bsd_ec,
-			bfddp_session_next_control_tx_interval(bs) / 1000,
+			bfddp_session_next_control_tx_interval(bs, true) / 1000,
 			bfd_session_control_tx_timeout, bs);
 		events_ctx_keep_timer(bsd->bsd_txev);
 	}


### PR DESCRIPTION
Summary
------------

Implement a BFD protocol adapter library extra part. The BFD data plane library will now handle some level of protocol logic to keep the software boiler plate code level low between vendor implementations. The new extra part is not mandatory, however recommended to vendors so they avoid repeating the BFD protocol logic and every one can share the same state machine/protocol handling.

The objective is to reduce maintenance work and code duplication.