### PR TITLE
relax version constraint to cmake 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.7)
 
 project(bfddp VERSION 0.1.0)
 


### PR DESCRIPTION
so the library can be built on a Debian Stretch image, without needing to add the backports.

Signed-off-by: Emanuele Di Pascale <emanuele@voltanet.io>