### PR TITLE
Split echo timers

### DIFF
--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -165,7 +165,7 @@ bfddp_session_update(struct bfd_session *bs, void *arg,
 	bool timers_changed = false;
 	struct in_addr *ia;
 	uint16_t port;
-	uint32_t min_rx, min_tx, min_erx;
+	uint32_t min_rx, min_tx, min_erx, min_etx;
 	uint8_t detect_mult;
 	uint32_t flags = ntohl(bds->flags);
 	bool echo_changed = false;
@@ -222,14 +222,16 @@ bfddp_session_update(struct bfd_session *bs, void *arg,
 	min_tx = ntohl(bds->min_tx);
 	min_rx = ntohl(bds->min_rx);
 	min_erx = ntohl(bds->min_echo_rx);
+	min_etx = ntohl(bds->min_echo_tx);
 	detect_mult = bds->detect_mult;
 	if (bs->bs_tx != min_tx || bs->bs_rx != min_rx || bs->bs_erx != min_erx
-	    || bs->bs_dmultiplier != detect_mult)
+	    || bs->bs_etx != min_etx || bs->bs_dmultiplier != detect_mult)
 		timers_changed = true;
 
 	bs->bs_tx = min_tx;
 	bs->bs_rx = min_rx;
 	bs->bs_erx = min_erx;
+	bs->bs_etx = min_etx;
 	bs->bs_hold = ntohl(bds->hold_time);
 	bs->bs_dmultiplier = detect_mult;
 
@@ -1111,8 +1113,8 @@ bfddp_session_next_echo_tx_interval(struct bfd_session *bs, bool add_jitter)
 	 * advertised value.  A single BFD Echo packet MAY be transmitted
 	 * between normally scheduled Echo transmission intervals.
 	 */
-	if (bs->bs_cur_erx > bs->bs_rerx)
-		selected_timer = bs->bs_cur_erx;
+	if (bs->bs_etx > bs->bs_rerx)
+		selected_timer = bs->bs_etx;
 	else
 		selected_timer = bs->bs_rerx;
 

--- a/libbfddp/bfddp_extra.c
+++ b/libbfddp/bfddp_extra.c
@@ -302,7 +302,7 @@ bfddp_session_update(struct bfd_session *bs, void *arg,
 	 * Echo mode changed, so start or stop the echo timers
 	 */
 	if (echo_changed && bs->bs_state == STATE_UP) {
-		if (bs->bs_echo) {
+		if (bs->bs_echo && bs->bs_rerx > 0) {
 			bfddp_callbacks.bc_rx_echo_update(bs, arg);
 			bfddp_callbacks.bc_tx_echo_update(bs, arg);
 		} else {
@@ -761,9 +761,12 @@ bfddp_session_rx_packet(struct bfd_session *bs, void *arg,
 
 		bfddp_callbacks.bc_tx_control_update(bs, arg);
 
-		if (bs->bs_echo) {
+		if (bs->bs_echo && bs->bs_rerx > 0) {
 			bfddp_callbacks.bc_tx_echo_update(bs, arg);
 			bfddp_callbacks.bc_rx_echo_update(bs, arg);
+		} else {
+			bfddp_callbacks.bc_tx_echo_stop(bs, arg);
+			bfddp_callbacks.bc_rx_echo_stop(bs, arg);
 		}
 
 		/* Tell control plane about timers change. */

--- a/libbfddp/bfddp_extra.h
+++ b/libbfddp/bfddp_extra.h
@@ -91,6 +91,8 @@ struct bfd_session {
 	uint32_t bs_erx;
 	/** Current required minimum echo receive interval. */
 	uint32_t bs_cur_erx;
+	/** Required minimum echo receive interval. */
+	uint32_t bs_etx;
 	/** Milliseconds to wait before starting session. */
 	uint32_t bs_hold;
 	/** Detection multiplier. */

--- a/libbfddp/bfddp_packet.h
+++ b/libbfddp/bfddp_packet.h
@@ -182,6 +182,11 @@ struct bfddp_session {
 	 */
 	uint32_t min_rx;
 	/**
+	 * Minimum desired echo transmission interval (in microseconds)
+	 * without jitter.
+	 */
+	uint32_t min_echo_tx;
+	/**
 	 * Required minimum echo receive interval rate (in microseconds)
 	 * without jitter.
 	 */

--- a/soft_bfddpd/debug.c
+++ b/soft_bfddpd/debug.c
@@ -107,12 +107,12 @@ void
 bfd_session_dump(const struct bfd_session *bs)
 {
 	bfd_session_debug(
-		bs, "%s%s%s%stx,rx,erx[%u,%u,%u r:%u,%u,%u] multi[%d, r:%d]",
+		bs, "%s%s%s%stx,rx,echo[%u,%u,(rx:%u, tx:%u) r:%u,%u,%u] multi[%d, r:%d]",
 		bs->bs_passive ? "passive " : "",
 		bs->bs_demand ? "demand " : "", bs->bs_cbit ? "cpi " : "",
 		bs->bs_echo ? "echo " : "", bs->bs_tx, bs->bs_rx, bs->bs_erx,
-		bs->bs_rtx, bs->bs_rrx, bs->bs_rerx, bs->bs_dmultiplier,
-		bs->bs_rdmultiplier);
+		bs->bs_etx, bs->bs_rtx, bs->bs_rrx, bs->bs_rerx,
+		bs->bs_dmultiplier, bs->bs_rdmultiplier);
 }
 
 const char *bfd_session_get_state_string(enum bfd_state_value state)


### PR DESCRIPTION
Summary
---

Split the handling of echo timers: one for minimum receive interval and another for minimum desired transmission interval. It also makes it possible to stop echo timers if remote system asks for minimum required echo interval of zero.

FRR already got this implemented here:
https://github.com/FRRouting/frr/pull/8229